### PR TITLE
Add ESP32-8048S070C board support

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -56,42 +56,53 @@ jobs:
       
     - name: Build firmware (Advance v1.2)
       run: platformio run --environment elecrow-crowpanel-7-advance-v12
-      
+
+    - name: Build firmware (ESP32-8048S070C)
+      run: platformio run --environment esp32-8048s070c
+
     - name: Prepare firmware files
       run: |
         # Create directories for all hardware variants
         mkdir -p web/firmware/basic
         mkdir -p web/firmware/advance-v1.3
         mkdir -p web/firmware/advance-v1.2
-        
+        mkdir -p web/firmware/esp32-8048s070c
+
         # Copy Basic variant firmware
         cp .pio/build/elecrow-crowpanel-7-basic/firmware.bin web/firmware/basic/
         cp .pio/build/elecrow-crowpanel-7-basic/bootloader.bin web/firmware/basic/
         cp .pio/build/elecrow-crowpanel-7-basic/partitions.bin web/firmware/basic/
-        
+
         # Copy Advance v1.3 variant firmware
         cp .pio/build/elecrow-crowpanel-7-advance-v13/firmware.bin web/firmware/advance-v1.3/
         cp .pio/build/elecrow-crowpanel-7-advance-v13/bootloader.bin web/firmware/advance-v1.3/
         cp .pio/build/elecrow-crowpanel-7-advance-v13/partitions.bin web/firmware/advance-v1.3/
-        
+
         # Copy Advance v1.2 variant firmware
         cp .pio/build/elecrow-crowpanel-7-advance-v12/firmware.bin web/firmware/advance-v1.2/
         cp .pio/build/elecrow-crowpanel-7-advance-v12/bootloader.bin web/firmware/advance-v1.2/
         cp .pio/build/elecrow-crowpanel-7-advance-v12/partitions.bin web/firmware/advance-v1.2/
-        
+
+        # Copy ESP32-8048S070C variant firmware
+        cp .pio/build/esp32-8048s070c/firmware.bin web/firmware/esp32-8048s070c/
+        cp .pio/build/esp32-8048s070c/bootloader.bin web/firmware/esp32-8048s070c/
+        cp .pio/build/esp32-8048s070c/partitions.bin web/firmware/esp32-8048s070c/
+
         # boot_app0.bin location varies, try common paths (same for all)
         if [ -f ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ]; then
           cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin web/firmware/basic/
           cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin web/firmware/advance-v1.3/
           cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin web/firmware/advance-v1.2/
+          cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin web/firmware/esp32-8048s070c/
         fi
-      
+
     - name: Update manifest files with version
       run: |
         sed -i 's/"version": ".*"/"version": "${{ steps.version.outputs.VERSION }}"/' web/manifest_basic.json
         sed -i 's/"version": ".*"/"version": "${{ steps.version.outputs.VERSION }}"/' web/manifest_advance-v1.3.json
         sed -i 's/"version": ".*"/"version": "${{ steps.version.outputs.VERSION }}"/' web/manifest_advance-v1.2.json
-        
+        sed -i 's/"version": ".*"/"version": "${{ steps.version.outputs.VERSION }}"/' web/manifest_esp32-8048s070c.json
+
     - name: Upload firmware artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -101,15 +112,17 @@ jobs:
           web/manifest_basic.json
           web/manifest_advance-v1.3.json
           web/manifest_advance-v1.2.json
+          web/manifest_esp32-8048s070c.json
           web/index.html
-          
+
     - name: Rename firmware files for release
       run: |
         mkdir -p release
         cp .pio/build/elecrow-crowpanel-7-basic/firmware.bin release/fluidtouch-basic-${{ steps.version.outputs.VERSION }}.bin
         cp .pio/build/elecrow-crowpanel-7-advance-v13/firmware.bin release/fluidtouch-advance-v1.3-${{ steps.version.outputs.VERSION }}.bin
         cp .pio/build/elecrow-crowpanel-7-advance-v12/firmware.bin release/fluidtouch-advance-v1.2-${{ steps.version.outputs.VERSION }}.bin
-        
+        cp .pio/build/esp32-8048s070c/firmware.bin release/fluidtouch-esp32-8048s070c-${{ steps.version.outputs.VERSION }}.bin
+
     - name: Create Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
@@ -118,25 +131,28 @@ jobs:
           release/fluidtouch-basic-${{ steps.version.outputs.VERSION }}.bin
           release/fluidtouch-advance-v1.3-${{ steps.version.outputs.VERSION }}.bin
           release/fluidtouch-advance-v1.2-${{ steps.version.outputs.VERSION }}.bin
+          release/fluidtouch-esp32-8048s070c-${{ steps.version.outputs.VERSION }}.bin
         body: |
           ## FluidTouch ${{ steps.version.outputs.VERSION }}
-          
+
           ### Web Installer
           Install directly from your browser: [FluidTouch Web Installer](https://jeyeager65.github.io/FluidTouch/)
-          
+
           Select your hardware variant during installation:
           - **Basic**: Elecrow CrowPanel 7" Basic (4MB flash, TN LCD, PWM backlight)
           - **Advance v1.3**: Elecrow CrowPanel 7" Advance v1.3 (16MB flash, IPS LCD, continuous brightness 0-245)
           - **Advance v1.2**: Elecrow CrowPanel 7" Advance v1.2 (16MB flash, IPS LCD, discrete brightness 0x05-0x10)
-          
+          - **ESP32-8048S070C**: ESP32-8048S070C ESP32-8048S070 (16MB flash, IPS LCD, PWM backlight)
+
           ### Manual Installation
           Download the appropriate firmware file for your hardware variant and flash using:
           - [esptool.py](https://docs.espressif.com/projects/esptool/en/latest/esp32s3/index.html): `esptool.py --chip esp32s3 write_flash 0x10000 fluidtouch-[variant]-${{ steps.version.outputs.VERSION }}.bin`
-          
+
           ### Hardware Requirements
           - Elecrow CrowPanel 7" ESP32-S3 HMI Display (Basic or Advance variant)
+          - ESP32-8048S070C ESP32-8048S070 7" Display
           - USB-C cable with data support
-          
+
           ### Installation Notes
           - **IMPORTANT**: Choose the correct firmware for your hardware variant
           - First-time installation will erase existing data
@@ -193,21 +209,25 @@ jobs:
         mkdir -p firmware/${VERSION}/basic
         mkdir -p firmware/${VERSION}/advance-v1.3
         mkdir -p firmware/${VERSION}/advance-v1.2
-        
+        mkdir -p firmware/${VERSION}/esp32-8048s070c
+
         # Copy firmware files (artifacts are in artifacts/firmware-VERSION/)
         find artifacts -path "*/basic/*.bin" -exec cp {} firmware/${VERSION}/basic/ \;
         find artifacts -path "*/advance-v1.3/*.bin" -exec cp {} firmware/${VERSION}/advance-v1.3/ \;
         find artifacts -path "*/advance-v1.2/*.bin" -exec cp {} firmware/${VERSION}/advance-v1.2/ \;
-        
+        find artifacts -path "*/esp32-8048s070c/*.bin" -exec cp {} firmware/${VERSION}/esp32-8048s070c/ \;
+
         # Copy and update manifests
         cp artifacts/firmware-*/manifest_basic.json firmware/${VERSION}/manifest_basic.json
         cp artifacts/firmware-*/manifest_advance-v1.3.json firmware/${VERSION}/manifest_advance-v1.3.json
         cp artifacts/firmware-*/manifest_advance-v1.2.json firmware/${VERSION}/manifest_advance-v1.2.json
-        
+        cp artifacts/firmware-*/manifest_esp32-8048s070c.json firmware/${VERSION}/manifest_esp32-8048s070c.json
+
         # Update manifest paths to point to version-specific firmware
         sed -i "s|./firmware/basic/|./firmware/${VERSION}/basic/|g" firmware/${VERSION}/manifest_basic.json
         sed -i "s|./firmware/advance-v1.3/|./firmware/${VERSION}/advance-v1.3/|g" firmware/${VERSION}/manifest_advance-v1.3.json
         sed -i "s|./firmware/advance-v1.2/|./firmware/${VERSION}/advance-v1.2/|g" firmware/${VERSION}/manifest_advance-v1.2.json
+        sed -i "s|./firmware/esp32-8048s070c/|./firmware/${VERSION}/esp32-8048s070c/|g" firmware/${VERSION}/manifest_esp32-8048s070c.json
         
     - name: Update versions.json
       run: |
@@ -219,14 +239,14 @@ jobs:
         
         # Load or create versions.json
         if [ ! -f versions.json ]; then
-          echo '{"default_version":null,"default_hardware":"advance-v1.3","versions":[],"hardware_info":{"basic":"Basic","advance-v1.3":"Advance v1.3","advance-v1.2":"Advance v1.2"}}' > versions.json
+          echo '{"default_version":null,"default_hardware":"advance-v1.3","versions":[],"hardware_info":{"basic":"Basic","advance-v1.3":"Advance v1.3","advance-v1.2":"Advance v1.2","esp32-8048s070c":"ESP32-8048S070C ESP32-8048S070"}}' > versions.json
         fi
         
         # Add new version entry
         jq --arg ver "$VERSION" --arg ts "$TIMESTAMP" '
           .versions = ([{
             "id": $ver,
-            "hardware": ["basic", "advance-v1.3", "advance-v1.2"],
+            "hardware": ["basic", "advance-v1.3", "advance-v1.2", "esp32-8048s070c"],
             "is_preview": false
           }] + .versions) |
           .default_version = $ver

--- a/include/config.h
+++ b/include/config.h
@@ -18,6 +18,12 @@
 #define TOUCH_SCL  16
 #define TOUCH_RST  -1  // Reset handled by STC8H1K28 microcontroller via I2C
 #define TOUCH_INT  -1  // Not used
+#elif defined(HARDWARE_ESP32_8048S070C)
+// ESP32-8048S070C
+#define TOUCH_SDA  19
+#define TOUCH_SCL  20
+#define TOUCH_RST  38  // GT911 reset pin
+#define TOUCH_INT  -1  // INT not used
 #else
 // CrowPanel 7" Basic
 #define TOUCH_SDA  19
@@ -60,7 +66,7 @@
 #define SD_CLK   5
 #define SD_CS    0  // Not actually connected - CS tied to GND in hardware (per Elecrow example)
 #else
-// Basic: SPI mode SD card
+// Basic / ESP32-8048S070C: SPI mode SD card
 #define SD_MOSI  11
 #define SD_MISO  13
 #define SD_CLK   12

--- a/platformio.ini
+++ b/platformio.ini
@@ -83,13 +83,31 @@ build_flags =
 [env:elecrow-crowpanel-7-advance-v13]
 board_upload.flash_size = 16MB
 board_build.partitions = default_16MB.csv
-build_unflags = 
+build_unflags =
     -Werror=all
-build_flags = 
+build_flags =
     ${env.build_flags}
     -DHARDWARE_ADVANCE
     -DBACKLIGHT_I2C
     -DBACKLIGHT_I2C_ADDR=0x30
+    -DARDUINO_USB_CDC_ON_BOOT=0
+    -DARDUINO_USB_MSC_ON_BOOT=0
+    -DARDUINO_USB_DFU_ON_BOOT=0
+
+; ============================================================================
+; ESP32-8048S070C
+; Hardware: ESP32-S3-WROOM-1 (8MB or 16MB Flash + 8MB Octal PSRAM)
+; Display: 800x480 RGB LCD, PCLK on IO42 (10Ω series resistor)
+; Touch: GT911 capacitive (IO19/IO20 I2C, IO38 RST)
+; Backlight: PWM on IO2
+; ============================================================================
+[env:esp32-8048s070c]
+board_upload.flash_size = 16MB
+board_build.partitions = default_16MB.csv
+build_flags =
+    ${env.build_flags}
+    -DHARDWARE_ESP32_8048S070C
+    -DBACKLIGHT_PWM
     -DARDUINO_USB_CDC_ON_BOOT=0
     -DARDUINO_USB_MSC_ON_BOOT=0
     -DARDUINO_USB_DFU_ON_BOOT=0

--- a/src/core/display_driver.cpp
+++ b/src/core/display_driver.cpp
@@ -8,7 +8,48 @@ LGFX::LGFX(void) {
         auto cfg = _bus_instance.config();
         cfg.panel = &_panel_instance;
         
-#ifdef HARDWARE_ADVANCE
+#if defined(HARDWARE_ESP32_8048S070C)
+        // ESP32-8048S070C ESP32-8048S070: 800x480 RGB LCD
+        // Same data bus as Basic; key difference: PCLK on IO42 (via 10Ω series resistor)
+        cfg.pin_d0  = GPIO_NUM_15; // B0
+        cfg.pin_d1  = GPIO_NUM_7;  // B1
+        cfg.pin_d2  = GPIO_NUM_6;  // B2
+        cfg.pin_d3  = GPIO_NUM_5;  // B3
+        cfg.pin_d4  = GPIO_NUM_4;  // B4
+
+        cfg.pin_d5  = GPIO_NUM_9;  // G0
+        cfg.pin_d6  = GPIO_NUM_46; // G1
+        cfg.pin_d7  = GPIO_NUM_3;  // G2
+        cfg.pin_d8  = GPIO_NUM_8;  // G3
+        cfg.pin_d9  = GPIO_NUM_16; // G4
+        cfg.pin_d10 = GPIO_NUM_1;  // G5
+
+        cfg.pin_d11 = GPIO_NUM_14; // R0
+        cfg.pin_d12 = GPIO_NUM_21; // R1
+        cfg.pin_d13 = GPIO_NUM_47; // R2
+        cfg.pin_d14 = GPIO_NUM_48; // R3
+        cfg.pin_d15 = GPIO_NUM_45; // R4
+
+        cfg.pin_henable = GPIO_NUM_41;
+        cfg.pin_vsync   = GPIO_NUM_40;
+        cfg.pin_hsync   = GPIO_NUM_39;
+        cfg.pin_pclk    = GPIO_NUM_42;  // IO42 with 10Ω series resistor to LCD DCLK
+        cfg.freq_write  = 12000000;  // 12MHz - higher speeds cause flickering under CPU load
+
+        cfg.hsync_polarity    = 0;
+        cfg.hsync_front_porch = 8;
+        cfg.hsync_pulse_width = 2;
+        cfg.hsync_back_porch  = 43;
+
+        cfg.vsync_polarity    = 0;
+        cfg.vsync_front_porch = 8;
+        cfg.vsync_pulse_width = 2;
+        cfg.vsync_back_porch  = 12;
+
+        cfg.pclk_active_neg   = 1;
+        cfg.de_idle_high      = 0;
+        cfg.pclk_idle_high    = 1;
+#elif defined(HARDWARE_ADVANCE)
         // Advance: IPS LCD (800x480) - Per Elecrow official example
         cfg.pin_d0  = GPIO_NUM_21; // B0
         cfg.pin_d1  = GPIO_NUM_47; // B1
@@ -104,8 +145,8 @@ LGFX::LGFX(void) {
         _panel_instance.config(cfg);
     }
     
-#ifdef HARDWARE_ADVANCE
-    // Enable PSRAM usage for Advance hardware (per Elecrow example)
+#if defined(HARDWARE_ADVANCE) || defined(HARDWARE_ESP32_8048S070C)
+    // Enable PSRAM usage (both Advance and ESP32-8048S070C have 8MB PSRAM)
     {
         auto cfg = _panel_instance.config_detail();
         cfg.use_psram = 1;
@@ -123,20 +164,30 @@ LGFX::LGFX(void) {
         cfg.x_max      = 799;
         cfg.y_min      = 0;
         cfg.y_max      = 479;
-        cfg.pin_int    = -1;   // Not used
         cfg.bus_shared = true;
         cfg.offset_rotation = 0;
 
 #ifdef HARDWARE_ADVANCE
         // Advance: Touch on different I2C pins
+        cfg.pin_int    = -1;
         cfg.i2c_port   = 0;
         cfg.i2c_addr   = 0x5D;
         cfg.pin_sda    = TOUCH_SDA;  // GPIO 15
         cfg.pin_scl    = TOUCH_SCL;  // GPIO 16
         cfg.pin_rst    = -1;  // Reset handled by STC8H1K28 via I2C
         cfg.freq       = 400000;     // Keep 400kHz - works well on Advance
+#elif defined(HARDWARE_ESP32_8048S070C)
+        // ESP32-8048S070C ESP32-8048S070: GT911 via I2C, INT on IO38
+        cfg.pin_int    = TOUCH_INT;  // -1 (not used)
+        cfg.i2c_port   = 0;
+        cfg.i2c_addr   = 0x5D;
+        cfg.pin_sda    = TOUCH_SDA;  // GPIO 19
+        cfg.pin_scl    = TOUCH_SCL;  // GPIO 20
+        cfg.pin_rst    = TOUCH_RST;  // GPIO 38
+        cfg.freq       = 400000;
 #else
         // Basic: Touch I2C configuration
+        cfg.pin_int    = -1;
         cfg.i2c_port   = 0;
         cfg.i2c_addr   = 0x5D;
         cfg.pin_sda    = TOUCH_SDA;  // GPIO 19

--- a/web/manifest_esp32-8048s070c.json
+++ b/web/manifest_esp32-8048s070c.json
@@ -1,0 +1,29 @@
+{
+  "name": "FluidTouch (ESP32-8048S070C)",
+  "version": "1.0.4",
+  "new_install_prompt_erase": true,
+  "funding_url": "https://github.com/jeyeager65/FluidTouch",
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "esp32-8048s070c/bootloader.bin",
+          "offset": 0
+        },
+        {
+          "path": "esp32-8048s070c/partitions.bin",
+          "offset": 32768
+        },
+        {
+          "path": "esp32-8048s070c/boot_app0.bin",
+          "offset": 57344
+        },
+        {
+          "path": "esp32-8048s070c/firmware.bin",
+          "offset": 65536
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Add new PlatformIO environment (esp32-8048s070c) with correct display timing (12MHz, pclk_idle_high=1, option-1 sync params) and touch config (GT911 RST=38, INT=-1)
- Add HARDWARE_ESP32_8048S070C define throughout display and config
- Add manifest_esp32-8048s070c.json for web installer
- Update GitHub Actions workflow to build, package, and release ESP32-8048S070C firmware