### PR TITLE
Add Battery Meter Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to FluidTouch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Battery Meter** - Live battery indicator for Advance hardware with a MAX17048 I2C fuel gauge
+  - Compact graphical battery icon with colored fill bar (green/amber/red) plus percentage text
+  - Charging state displayed with a lightning bolt overlay and cyan color
+  - Visible in both the main UI status bar and the machine selection screen
+  - MAX17048 is auto-detected on the I2C bus at startup - battery monitoring is silently disabled if the chip is not present, so the feature is opt-in via hardware
+
 ## [1.0.4] - 2026-03-23
 
 ### Added

--- a/include/config.h
+++ b/include/config.h
@@ -70,4 +70,14 @@
 // Upload Configuration
 #define FLUIDNC_UPLOAD_PATH "/fluidtouch/uploads/"  // Automatically created if missing
 
+// Battery Monitor Configuration (MAX17048 I2C Fuel Gauge)
+// The MAX17048 connects to the I2C bus (shared with touch controller).
+// It auto-detects on init - if not found, battery monitoring is disabled gracefully.
+// Comment out BATTERY_ENABLED to disable battery monitoring entirely.
+#define BATTERY_ENABLED
+#define MAX17048_ADDR           0x36      // MAX17048 I2C address (fixed)
+#define BATTERY_VOLTAGE_MAX     4.2f      // Fully charged voltage (Li-ion/LiPo)
+#define BATTERY_VOLTAGE_MIN     3.0f      // Empty voltage (Li-ion cutoff)
+#define BATTERY_CHARGE_RATE_THRESHOLD 0.5f // %/hour above which we consider "charging"
+
 #endif // CONFIG_H

--- a/include/core/battery_monitor.h
+++ b/include/core/battery_monitor.h
@@ -1,0 +1,56 @@
+#ifndef BATTERY_MONITOR_H
+#define BATTERY_MONITOR_H
+
+#include <cstdint>
+
+// Battery charging state
+enum BatteryState {
+    BATTERY_DISCHARGING,  // Running on battery
+    BATTERY_CHARGING,     // USB/DC power present, battery charging
+    BATTERY_CHARGED       // USB/DC power present, battery full
+};
+
+// Battery monitoring via MAX17048 I2C fuel gauge
+// Auto-detects the chip on the I2C bus at init time.
+// If not found, battery monitoring is disabled gracefully.
+class BatteryMonitor {
+public:
+    // Initialize battery monitor - detects MAX17048 on I2C bus
+    static void init();
+
+    // Read battery state - call periodically (every 1-2 seconds is sufficient)
+    static void update();
+
+    // Getters for current battery status
+    static uint8_t getPercentage() { return percentage; }
+    static float getVoltage() { return voltage; }
+    static BatteryState getState() { return state; }
+    static bool isEnabled() { return enabled; }
+
+    // Get LVGL symbol string for current battery level
+    static const char* getBatterySymbol();
+
+private:
+    static bool enabled;
+    static uint8_t percentage;         // 0-100%
+    static float voltage;              // Current cell voltage
+    static BatteryState state;
+    static float charge_rate;          // %/hour (positive = charging, negative = discharging)
+
+    // MAX17048 register addresses
+    static constexpr uint8_t REG_VCELL   = 0x02;  // Cell voltage
+    static constexpr uint8_t REG_SOC     = 0x04;  // State of charge (%)
+    static constexpr uint8_t REG_MODE    = 0x06;  // Mode register
+    static constexpr uint8_t REG_VERSION = 0x08;  // IC version
+    static constexpr uint8_t REG_CONFIG  = 0x0C;  // Configuration
+    static constexpr uint8_t REG_CRATE   = 0x16;  // Charge rate (%/hr)
+
+    // I2C helpers
+    static uint16_t readRegister(uint8_t reg);
+    static bool detectChip();
+    static float readCellVoltage();
+    static uint8_t readSOC();
+    static float readChargeRate();
+};
+
+#endif // BATTERY_MONITOR_H

--- a/include/ui/ui_common.h
+++ b/include/ui/ui_common.h
@@ -21,6 +21,7 @@ public:
     static void updateWorkPosition(float x, float y, float z, float a = -9999.0f);
     static void updateMachineState(const char *state);
     static void updateConnectionStatus(bool machine_connected, bool wifi_connected);
+    static void updateBattery(uint8_t percentage, int state);  // state: 0=discharging, 1=charging, 2=charged
     static void updateFileProgress(bool is_printing, float percent, const char *filename, uint32_t elapsed_ms);
     
     // Dialog functions
@@ -104,6 +105,15 @@ private:
     // Cached values for delta checking (prevent unnecessary redraws)
     static float last_wpos_x, last_wpos_y, last_wpos_z, last_wpos_a;
     static float last_mpos_x, last_mpos_y, last_mpos_z;
+
+    // Battery indicator (compact graphical widget: outline + fill bar + nub + % label)
+    static lv_obj_t *battery_body;        // Battery outline rectangle
+    static lv_obj_t *battery_fill;        // Inner fill bar (lv_bar)
+    static lv_obj_t *battery_nub;         // Small nub on the right side
+    static lv_obj_t *lbl_battery_charge;  // Lightning bolt overlay when charging
+    static lv_obj_t *lbl_battery_percent; // Percentage text next to battery
+    static uint8_t last_battery_pct;
+    static int last_battery_state;
 
     // Cached system preferences (loaded once at startup)
     static bool enable_a_axis;

--- a/include/ui/ui_machine_select.h
+++ b/include/ui/ui_machine_select.h
@@ -8,7 +8,10 @@ class UIMachineSelect {
 public:
     static void show(lv_display_t *disp);
     static void hide();
-    
+
+    // Battery indicator update (called from main loop)
+    static void updateBattery(uint8_t percentage, int state);
+
 private:
     static lv_obj_t *screen;
     static lv_display_t *display;
@@ -58,6 +61,15 @@ private:
     static void onConnectionTypeChanged(lv_event_t *e);
     static void onTextareaFocused(lv_event_t *e);
     
+    // Battery indicator (compact graphical widget)
+    static lv_obj_t *battery_body;
+    static lv_obj_t *battery_fill;
+    static lv_obj_t *battery_nub;
+    static lv_obj_t *lbl_battery_charge;
+    static lv_obj_t *lbl_battery_percent;
+    static uint8_t last_battery_pct;
+    static int last_battery_state;
+
     // Helper functions
     static void refreshMachineList();
     static void showConfigDialog(int index);

--- a/include/ui/ui_theme.h
+++ b/include/ui/ui_theme.h
@@ -69,6 +69,12 @@ namespace UITheme {
     // LED/Indicator Colors
     static constexpr lv_color_t LED_OFF = LV_COLOR_MAKE(0x66, 0x66, 0x66);      // LED inactive
     
+    // Battery Indicator Colors
+    static constexpr lv_color_t BATTERY_FULL = LV_COLOR_MAKE(0x4C, 0xAF, 0x50);      // Green (>55%)
+    static constexpr lv_color_t BATTERY_MID = LV_COLOR_MAKE(0xFF, 0xB7, 0x4D);       // Amber (20-55%)
+    static constexpr lv_color_t BATTERY_LOW = LV_COLOR_MAKE(0xFF, 0x00, 0x00);       // Red (<20%)
+    static constexpr lv_color_t BATTERY_CHARGING = LV_COLOR_MAKE(0x00, 0xBF, 0xFF);  // Cyan (charging)
+
     // Joystick/Control Colors
     static constexpr lv_color_t JOYSTICK_BG = LV_COLOR_MAKE(0x30, 0x30, 0x30);  // Joystick background
     static constexpr lv_color_t JOYSTICK_LINE = LV_COLOR_MAKE(0x60, 0x60, 0x60); // Joystick crosshairs

--- a/src/core/battery_monitor.cpp
+++ b/src/core/battery_monitor.cpp
@@ -1,0 +1,141 @@
+#include "core/battery_monitor.h"
+#include "config.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include <lvgl.h>
+
+// Static member initialization
+bool BatteryMonitor::enabled = false;
+uint8_t BatteryMonitor::percentage = 0;
+float BatteryMonitor::voltage = 0.0f;
+BatteryState BatteryMonitor::state = BATTERY_DISCHARGING;
+float BatteryMonitor::charge_rate = 0.0f;
+
+void BatteryMonitor::init() {
+#ifdef BATTERY_ENABLED
+    // Detect MAX17048 on the I2C bus
+    if (!detectChip()) {
+        enabled = false;
+        Serial.println("[Battery] MAX17048 not found on I2C bus - battery monitor disabled");
+        return;
+    }
+
+    enabled = true;
+
+    // Take initial readings
+    voltage = readCellVoltage();
+    percentage = readSOC();
+    charge_rate = readChargeRate();
+
+    // Determine initial state
+    if (charge_rate > BATTERY_CHARGE_RATE_THRESHOLD) {
+        state = (percentage >= 99) ? BATTERY_CHARGED : BATTERY_CHARGING;
+    } else {
+        state = BATTERY_DISCHARGING;
+    }
+
+    Serial.printf("[Battery] MAX17048 detected - voltage: %.2fV, SOC: %d%%, rate: %.1f%%/hr\n",
+                  voltage, percentage, charge_rate);
+#else
+    enabled = false;
+    Serial.println("[Battery] Battery monitoring disabled in config");
+#endif
+}
+
+void BatteryMonitor::update() {
+#ifdef BATTERY_ENABLED
+    if (!enabled) return;
+
+    // Read all values from MAX17048
+    voltage = readCellVoltage();
+    percentage = readSOC();
+    charge_rate = readChargeRate();
+
+    // Determine charging state from charge rate
+    // CRATE > threshold = charging, near zero + high SOC = charged, otherwise discharging
+    if (charge_rate > BATTERY_CHARGE_RATE_THRESHOLD) {
+        if (percentage >= 99) {
+            state = BATTERY_CHARGED;
+        } else {
+            state = BATTERY_CHARGING;
+        }
+    } else if (percentage >= 99 && charge_rate >= 0.0f) {
+        // Battery full and not discharging (could be on USB power)
+        state = BATTERY_CHARGED;
+    } else {
+        state = BATTERY_DISCHARGING;
+    }
+#endif
+}
+
+bool BatteryMonitor::detectChip() {
+    // Try to communicate with MAX17048 at its I2C address
+    Wire.beginTransmission(MAX17048_ADDR);
+    uint8_t error = Wire.endTransmission();
+
+    if (error != 0) {
+        return false;
+    }
+
+    // Read VERSION register to verify it's actually a MAX17048/MAX17049
+    uint16_t version = readRegister(REG_VERSION);
+    if (version == 0 || version == 0xFFFF) {
+        Serial.printf("[Battery] Invalid MAX17048 version: 0x%04X\n", version);
+        return false;
+    }
+
+    Serial.printf("[Battery] MAX17048 version: 0x%04X\n", version);
+    return true;
+}
+
+uint16_t BatteryMonitor::readRegister(uint8_t reg) {
+    Wire.beginTransmission(MAX17048_ADDR);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) {
+        return 0;
+    }
+
+    if (Wire.requestFrom((uint8_t)MAX17048_ADDR, (uint8_t)2) != 2) {
+        return 0;
+    }
+
+    uint8_t msb = Wire.read();
+    uint8_t lsb = Wire.read();
+    return ((uint16_t)msb << 8) | lsb;
+}
+
+float BatteryMonitor::readCellVoltage() {
+    // VCELL register (0x02): 16-bit value, resolution = 78.125uV per unit
+    // Voltage = raw * 78.125e-6
+    uint16_t raw = readRegister(REG_VCELL);
+    return raw * 78.125e-6f;
+}
+
+uint8_t BatteryMonitor::readSOC() {
+    // SOC register (0x04): MSB = whole percent, LSB = 1/256th percent
+    uint16_t raw = readRegister(REG_SOC);
+    uint8_t whole = (uint8_t)(raw >> 8);
+
+    // Clamp to 0-100
+    if (whole > 100) whole = 100;
+    return whole;
+}
+
+float BatteryMonitor::readChargeRate() {
+    // CRATE register (0x16): signed 16-bit, units of 0.208%/hr
+    // Positive = charging, negative = discharging
+    uint16_t raw = readRegister(REG_CRATE);
+    int16_t signed_raw = (int16_t)raw;
+    return signed_raw * 0.208f;
+}
+
+const char* BatteryMonitor::getBatterySymbol() {
+    if (state == BATTERY_CHARGING) {
+        return LV_SYMBOL_CHARGE;
+    }
+    if (percentage >= 80) return LV_SYMBOL_BATTERY_FULL;
+    if (percentage >= 55) return LV_SYMBOL_BATTERY_3;
+    if (percentage >= 30) return LV_SYMBOL_BATTERY_2;
+    if (percentage >= 10) return LV_SYMBOL_BATTERY_1;
+    return LV_SYMBOL_BATTERY_EMPTY;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "core/display_driver.h"     // Display driver module
 #include "core/touch_driver.h"       // Touch driver module
 #include "core/power_manager.h"      // Power management module
+#include "core/battery_monitor.h"    // Battery monitoring module
 #include "network/screenshot_server.h"  // Screenshot web server
 #include "network/fluidnc_client.h"     // FluidNC WebSocket client
 #include "ui/ui_theme.h"        // UI theme colors
@@ -64,6 +65,10 @@ void setup()
     Serial.println("Initializing power manager...");
     PowerManager::init(&displayDriver);
     Serial.println("Power manager initialized successfully");
+
+    // Initialize Battery Monitor
+    Serial.println("Initializing battery monitor...");
+    BatteryMonitor::init();
 
     // Store display driver reference for later use (screenshot server after WiFi connects)
     UICommon::setDisplayDriver(&displayDriver);
@@ -176,6 +181,15 @@ void loop()
         
         // Update connection status symbols (always update, even if not connected)
         UICommon::updateConnectionStatus(machine_connected, wifi_connected);
+
+        // Update battery monitor (read MAX17048 I2C fuel gauge and update UI)
+        if (BatteryMonitor::isEnabled()) {
+            BatteryMonitor::update();
+            uint8_t batt_pct = BatteryMonitor::getPercentage();
+            int batt_state = (int)BatteryMonitor::getState();
+            UICommon::updateBattery(batt_pct, batt_state);
+            UIMachineSelect::updateBattery(batt_pct, batt_state);
+        }
         
         // Update About tab screenshot server URL (in case WiFi status changed)
         UITabSettingsAbout::update();

--- a/src/ui/ui_common.cpp
+++ b/src/ui/ui_common.cpp
@@ -683,11 +683,13 @@ void UICommon::createStatusBar() {
         lv_obj_set_style_bg_color(battery_fill, UITheme::BATTERY_FULL, LV_PART_INDICATOR);
         lv_obj_set_style_radius(battery_fill, 0, LV_PART_INDICATOR);
 
-        // Lightning bolt overlay for charging state (hidden by default)
+        // Lightning bolt overlay for charging state (hidden by default).
+        // Uses a high-contrast light color so it stands out against the cyan
+        // charging fill behind it.
         lbl_battery_charge = lv_label_create(status_bar);
         lv_label_set_text(lbl_battery_charge, LV_SYMBOL_CHARGE);
         lv_obj_set_style_text_font(lbl_battery_charge, &lv_font_montserrat_14, 0);
-        lv_obj_set_style_text_color(lbl_battery_charge, UITheme::BATTERY_CHARGING, 0);
+        lv_obj_set_style_text_color(lbl_battery_charge, UITheme::TEXT_LIGHT, 0);
         lv_obj_align_to(lbl_battery_charge, battery_body, LV_ALIGN_CENTER, 0, 0);
         lv_obj_add_flag(lbl_battery_charge, LV_OBJ_FLAG_HIDDEN);
     }

--- a/src/ui/ui_common.cpp
+++ b/src/ui/ui_common.cpp
@@ -6,6 +6,7 @@
 #include "network/fluidnc_client.h"
 #include "core/display_driver.h"
 #include "core/power_manager.h"
+#include "core/battery_monitor.h"
 #include "network/screenshot_server.h"
 #include "config.h"
 #include <Preferences.h>
@@ -69,6 +70,15 @@ float UICommon::last_wpos_a = -9999.0f;
 float UICommon::last_mpos_x = -9999.0f;
 float UICommon::last_mpos_y = -9999.0f;
 float UICommon::last_mpos_z = -9999.0f;
+
+// Battery indicator (compact graphical widget)
+lv_obj_t *UICommon::battery_body = nullptr;
+lv_obj_t *UICommon::battery_fill = nullptr;
+lv_obj_t *UICommon::battery_nub = nullptr;
+lv_obj_t *UICommon::lbl_battery_charge = nullptr;
+lv_obj_t *UICommon::lbl_battery_percent = nullptr;
+uint8_t UICommon::last_battery_pct = 255;  // Force first update
+int UICommon::last_battery_state = -1;
 
 // Cached system preferences (loaded once at startup)
 bool UICommon::enable_a_axis = false;
@@ -562,20 +572,25 @@ void UICommon::createStatusBar() {
     
     if (MachineConfigManager::getSelectedMachine(selected_machine)) {
         const char *symbol = (selected_machine.connection_type == CONN_WIRELESS) ? LV_SYMBOL_WIFI : LV_SYMBOL_USB;
-        
+
         // Symbol (will be colored based on connection status)
         lbl_machine_symbol = lv_label_create(status_bar);
         lv_label_set_text(lbl_machine_symbol, symbol);
         lv_obj_set_style_text_font(lbl_machine_symbol, &lv_font_montserrat_18, 0);
         lv_obj_set_style_text_color(lbl_machine_symbol, UITheme::STATE_ALARM, 0);  // Start red
         lv_obj_align(lbl_machine_symbol, LV_ALIGN_TOP_RIGHT, -5, 3);
-        
-        // Machine name
+
+        // Machine name - fixed width, right-aligned (mirrors wifi_name layout for consistency)
+        // Width kept compact so the battery widget has room between WPos Z and the machine name.
+        // Names longer than this width are truncated with an ellipsis.
         lbl_machine_name = lv_label_create(status_bar);
         lv_label_set_text(lbl_machine_name, selected_machine.name);
         lv_obj_set_style_text_font(lbl_machine_name, &lv_font_montserrat_18, 0);
         lv_obj_set_style_text_color(lbl_machine_name, UITheme::ACCENT_PRIMARY, 0);
-        lv_obj_align_to(lbl_machine_name, lbl_machine_symbol, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+        lv_obj_set_style_text_align(lbl_machine_name, LV_TEXT_ALIGN_RIGHT, 0);
+        lv_label_set_long_mode(lbl_machine_name, LV_LABEL_LONG_DOT);
+        lv_obj_set_width(lbl_machine_name, 80);  // Compact width to leave room for battery
+        lv_obj_align(lbl_machine_name, LV_ALIGN_TOP_RIGHT, -32, 3);
     } else {
         lbl_modal_states = lv_label_create(status_bar);
         lv_label_set_text(lbl_modal_states, "No Machine");
@@ -614,6 +629,68 @@ void UICommon::createStatusBar() {
     lv_obj_set_style_text_font(lbl_wifi_symbol, &lv_font_montserrat_18, 0);
     lv_obj_set_style_text_color(lbl_wifi_symbol, WiFi.isConnected() ? UITheme::STATE_IDLE : UITheme::STATE_ALARM, 0);
     lv_obj_align(lbl_wifi_symbol, LV_ALIGN_BOTTOM_RIGHT, -5, -3);
+
+    // Battery indicator (only shown when battery monitor is enabled)
+    // Compact graphical battery: outline + fill bar + nub, with percentage text.
+    // Positioned on the top line, left of the fixed-width machine_name/symbol area.
+    // Total footprint is ~72px (percent text: ~36px + gap + battery graphic: ~32px).
+    if (BatteryMonitor::isEnabled()) {
+        // Percentage text - placed first so battery can align to its left
+        lbl_battery_percent = lv_label_create(status_bar);
+        lv_label_set_text(lbl_battery_percent, "100%");
+        lv_obj_set_style_text_font(lbl_battery_percent, &lv_font_montserrat_14, 0);
+        lv_obj_set_style_text_color(lbl_battery_percent, UITheme::BATTERY_FULL, 0);
+        lv_obj_set_style_text_align(lbl_battery_percent, LV_TEXT_ALIGN_RIGHT, 0);
+        lv_obj_set_width(lbl_battery_percent, 36);
+        // Anchor to left of machine_name (if exists) with 8px gap for breathing room
+        lv_obj_t *anchor = lbl_machine_name ? lbl_machine_name : lbl_machine_symbol;
+        if (anchor) {
+            lv_obj_align_to(lbl_battery_percent, anchor, LV_ALIGN_OUT_LEFT_MID, -8, 0);
+        } else {
+            lv_obj_align(lbl_battery_percent, LV_ALIGN_TOP_RIGHT, -45, 8);
+        }
+
+        // Battery nub (tiny rectangle on the right side of the battery body)
+        battery_nub = lv_obj_create(status_bar);
+        lv_obj_set_size(battery_nub, 2, 6);
+        lv_obj_set_style_bg_color(battery_nub, UITheme::BATTERY_FULL, 0);
+        lv_obj_set_style_border_width(battery_nub, 0, 0);
+        lv_obj_set_style_radius(battery_nub, 0, 0);
+        lv_obj_set_style_pad_all(battery_nub, 0, 0);
+        lv_obj_clear_flag(battery_nub, LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_align_to(battery_nub, lbl_battery_percent, LV_ALIGN_OUT_LEFT_MID, -4, 0);
+
+        // Battery body (outline rectangle with colored border, hollow inside)
+        battery_body = lv_obj_create(status_bar);
+        lv_obj_set_size(battery_body, 28, 14);
+        lv_obj_set_style_bg_color(battery_body, UITheme::BG_DARK, 0);
+        lv_obj_set_style_border_color(battery_body, UITheme::BATTERY_FULL, 0);
+        lv_obj_set_style_border_width(battery_body, 1, 0);
+        lv_obj_set_style_radius(battery_body, 2, 0);
+        lv_obj_set_style_pad_all(battery_body, 1, 0);
+        lv_obj_clear_flag(battery_body, LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_align_to(battery_body, battery_nub, LV_ALIGN_OUT_LEFT_MID, 0, 0);
+
+        // Inner fill bar (shows percentage visually)
+        battery_fill = lv_bar_create(battery_body);
+        lv_obj_set_size(battery_fill, LV_PCT(100), LV_PCT(100));
+        lv_obj_center(battery_fill);
+        lv_bar_set_range(battery_fill, 0, 100);
+        lv_bar_set_value(battery_fill, 100, LV_ANIM_OFF);
+        lv_obj_set_style_bg_opa(battery_fill, LV_OPA_TRANSP, 0);
+        lv_obj_set_style_border_width(battery_fill, 0, 0);
+        lv_obj_set_style_radius(battery_fill, 0, 0);
+        lv_obj_set_style_bg_color(battery_fill, UITheme::BATTERY_FULL, LV_PART_INDICATOR);
+        lv_obj_set_style_radius(battery_fill, 0, LV_PART_INDICATOR);
+
+        // Lightning bolt overlay for charging state (hidden by default)
+        lbl_battery_charge = lv_label_create(status_bar);
+        lv_label_set_text(lbl_battery_charge, LV_SYMBOL_CHARGE);
+        lv_obj_set_style_text_font(lbl_battery_charge, &lv_font_montserrat_14, 0);
+        lv_obj_set_style_text_color(lbl_battery_charge, UITheme::BATTERY_CHARGING, 0);
+        lv_obj_align_to(lbl_battery_charge, battery_body, LV_ALIGN_CENTER, 0, 0);
+        lv_obj_add_flag(lbl_battery_charge, LV_OBJ_FLAG_HIDDEN);
+    }
 }
 
 void UICommon::updateModalStates(const char *text) {
@@ -761,6 +838,54 @@ void UICommon::updateConnectionStatus(bool machine_connected, bool wifi_connecte
             wifi_connected ? UITheme::STATE_IDLE : UITheme::STATE_ALARM, 0);
         last_wifi_connected = wifi_connected;
     }
+}
+
+void UICommon::updateBattery(uint8_t percentage, int state) {
+    if (!battery_body || !battery_fill || !battery_nub || !lbl_battery_percent) return;
+
+    // Only update when values actually change
+    if (percentage == last_battery_pct && state == last_battery_state) return;
+
+    // Determine color based on state and percentage
+    lv_color_t color;
+    if (state == 1) {  // BATTERY_CHARGING
+        color = UITheme::BATTERY_CHARGING;
+    } else if (state == 2) {  // BATTERY_CHARGED
+        color = UITheme::BATTERY_FULL;
+    } else if (percentage < 20) {
+        color = UITheme::BATTERY_LOW;
+    } else if (percentage < 55) {
+        color = UITheme::BATTERY_MID;
+    } else {
+        color = UITheme::BATTERY_FULL;
+    }
+
+    // Update fill bar value (use at least 5% so some color is visible even near empty)
+    uint8_t display_value = (percentage < 5 && percentage > 0) ? 5 : percentage;
+    lv_bar_set_value(battery_fill, display_value, LV_ANIM_OFF);
+
+    // Update colors: outline, fill, nub, and text
+    lv_obj_set_style_border_color(battery_body, color, 0);
+    lv_obj_set_style_bg_color(battery_fill, color, LV_PART_INDICATOR);
+    lv_obj_set_style_bg_color(battery_nub, color, 0);
+    lv_obj_set_style_text_color(lbl_battery_percent, color, 0);
+
+    // Show/hide charging bolt overlay
+    if (lbl_battery_charge) {
+        if (state == 1) {  // Charging
+            lv_obj_clear_flag(lbl_battery_charge, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_add_flag(lbl_battery_charge, LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+
+    // Update percentage text
+    char buf[8];
+    snprintf(buf, sizeof(buf), "%d%%", percentage);
+    lv_label_set_text(lbl_battery_percent, buf);
+
+    last_battery_pct = percentage;
+    last_battery_state = state;
 }
 
 void UICommon::showMachineSelectConfirmDialog() {

--- a/src/ui/ui_machine_select.cpp
+++ b/src/ui/ui_machine_select.cpp
@@ -3,6 +3,7 @@
 #include "ui/ui_tabs.h"
 #include "ui/ui_theme.h"
 #include "core/power_manager.h"
+#include "core/battery_monitor.h"
 #include "config.h"
 #include <Preferences.h>
 
@@ -32,6 +33,15 @@ lv_obj_t *UIMachineSelect::dd_connection_type = nullptr;
 lv_obj_t *UIMachineSelect::delete_dialog = nullptr;
 int UIMachineSelect::deleting_index = -1;
 
+// Battery indicator (compact graphical widget)
+lv_obj_t *UIMachineSelect::battery_body = nullptr;
+lv_obj_t *UIMachineSelect::battery_fill = nullptr;
+lv_obj_t *UIMachineSelect::battery_nub = nullptr;
+lv_obj_t *UIMachineSelect::lbl_battery_charge = nullptr;
+lv_obj_t *UIMachineSelect::lbl_battery_percent = nullptr;
+uint8_t UIMachineSelect::last_battery_pct = 255;  // Force first update
+int UIMachineSelect::last_battery_state = -1;
+
 void UIMachineSelect::show(lv_display_t *disp) {
     display = disp;
     Serial.println("UIMachineSelect: Creating machine selection screen");
@@ -52,7 +62,68 @@ void UIMachineSelect::show(lv_display_t *disp) {
     lv_obj_set_style_text_font(title, &lv_font_montserrat_32, 0);  // Larger font
     lv_obj_set_style_text_color(title, UITheme::TEXT_LIGHT, 0);
     lv_obj_align(title, LV_ALIGN_TOP_LEFT, 20, 15);
-    
+
+    // Battery indicator (compact graphical widget, placed after title)
+    if (BatteryMonitor::isEnabled()) {
+        last_battery_pct = 255;   // Force first update
+        last_battery_state = -1;
+
+        // Battery body (outline rectangle)
+        battery_body = lv_obj_create(screen);
+        lv_obj_set_size(battery_body, 28, 14);
+        lv_obj_set_style_bg_color(battery_body, UITheme::BG_DARK, 0);
+        lv_obj_set_style_border_color(battery_body, UITheme::BATTERY_FULL, 0);
+        lv_obj_set_style_border_width(battery_body, 1, 0);
+        lv_obj_set_style_radius(battery_body, 2, 0);
+        lv_obj_set_style_pad_all(battery_body, 1, 0);
+        lv_obj_clear_flag(battery_body, LV_OBJ_FLAG_SCROLLABLE);
+        // Bottom-align to the title baseline with 20px gap
+        lv_obj_align_to(battery_body, title, LV_ALIGN_OUT_RIGHT_BOTTOM, 20, -6);
+
+        // Nub on right side of battery
+        battery_nub = lv_obj_create(screen);
+        lv_obj_set_size(battery_nub, 2, 6);
+        lv_obj_set_style_bg_color(battery_nub, UITheme::BATTERY_FULL, 0);
+        lv_obj_set_style_border_width(battery_nub, 0, 0);
+        lv_obj_set_style_radius(battery_nub, 0, 0);
+        lv_obj_set_style_pad_all(battery_nub, 0, 0);
+        lv_obj_clear_flag(battery_nub, LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_align_to(battery_nub, battery_body, LV_ALIGN_OUT_RIGHT_MID, 0, 0);
+
+        // Inner fill bar
+        battery_fill = lv_bar_create(battery_body);
+        lv_obj_set_size(battery_fill, LV_PCT(100), LV_PCT(100));
+        lv_obj_center(battery_fill);
+        lv_bar_set_range(battery_fill, 0, 100);
+        lv_bar_set_value(battery_fill, 100, LV_ANIM_OFF);
+        lv_obj_set_style_bg_opa(battery_fill, LV_OPA_TRANSP, 0);
+        lv_obj_set_style_border_width(battery_fill, 0, 0);
+        lv_obj_set_style_radius(battery_fill, 0, 0);
+        lv_obj_set_style_bg_color(battery_fill, UITheme::BATTERY_FULL, LV_PART_INDICATOR);
+        lv_obj_set_style_radius(battery_fill, 0, LV_PART_INDICATOR);
+
+        // Lightning bolt overlay for charging (hidden by default)
+        lbl_battery_charge = lv_label_create(screen);
+        lv_label_set_text(lbl_battery_charge, LV_SYMBOL_CHARGE);
+        lv_obj_set_style_text_font(lbl_battery_charge, &lv_font_montserrat_14, 0);
+        lv_obj_set_style_text_color(lbl_battery_charge, UITheme::BATTERY_CHARGING, 0);
+        lv_obj_align_to(lbl_battery_charge, battery_body, LV_ALIGN_CENTER, 0, 0);
+        lv_obj_add_flag(lbl_battery_charge, LV_OBJ_FLAG_HIDDEN);
+
+        // Percentage label - right of the battery graphic
+        lbl_battery_percent = lv_label_create(screen);
+        lv_label_set_text(lbl_battery_percent, "100%");
+        lv_obj_set_style_text_font(lbl_battery_percent, &lv_font_montserrat_16, 0);
+        lv_obj_set_style_text_color(lbl_battery_percent, UITheme::BATTERY_FULL, 0);
+        lv_obj_align_to(lbl_battery_percent, battery_nub, LV_ALIGN_OUT_RIGHT_MID, 4, 0);
+    } else {
+        battery_body = nullptr;
+        battery_fill = nullptr;
+        battery_nub = nullptr;
+        lbl_battery_charge = nullptr;
+        lbl_battery_percent = nullptr;
+    }
+
     // Button container for right-aligned buttons
     lv_obj_t *btn_container = lv_obj_create(screen);
     lv_obj_set_size(btn_container, LV_SIZE_CONTENT, 45);
@@ -114,7 +185,7 @@ void UIMachineSelect::show(lv_display_t *disp) {
     lv_obj_clear_flag(list_container, LV_OBJ_FLAG_SCROLLABLE);
     
     refreshMachineList();
-    
+
     // Load screen
     lv_scr_load(screen);
     
@@ -137,6 +208,59 @@ void UIMachineSelect::hide() {
         lv_obj_del(screen);
         screen = nullptr;
     }
+    battery_body = nullptr;
+    battery_fill = nullptr;
+    battery_nub = nullptr;
+    lbl_battery_charge = nullptr;
+    lbl_battery_percent = nullptr;
+}
+
+void UIMachineSelect::updateBattery(uint8_t percentage, int state) {
+    if (!battery_body || !battery_fill || !battery_nub || !lbl_battery_percent) return;
+
+    // Only update when values actually change
+    if (percentage == last_battery_pct && state == last_battery_state) return;
+
+    // Determine color based on state and percentage
+    lv_color_t color;
+    if (state == 1) {  // BATTERY_CHARGING
+        color = UITheme::BATTERY_CHARGING;
+    } else if (state == 2) {  // BATTERY_CHARGED
+        color = UITheme::BATTERY_FULL;
+    } else if (percentage < 20) {
+        color = UITheme::BATTERY_LOW;
+    } else if (percentage < 55) {
+        color = UITheme::BATTERY_MID;
+    } else {
+        color = UITheme::BATTERY_FULL;
+    }
+
+    // Update fill bar value (clamp low so some color is visible near empty)
+    uint8_t display_value = (percentage < 5 && percentage > 0) ? 5 : percentage;
+    lv_bar_set_value(battery_fill, display_value, LV_ANIM_OFF);
+
+    // Update colors: outline, fill, nub, text
+    lv_obj_set_style_border_color(battery_body, color, 0);
+    lv_obj_set_style_bg_color(battery_fill, color, LV_PART_INDICATOR);
+    lv_obj_set_style_bg_color(battery_nub, color, 0);
+    lv_obj_set_style_text_color(lbl_battery_percent, color, 0);
+
+    // Show/hide charging bolt overlay
+    if (lbl_battery_charge) {
+        if (state == 1) {  // Charging
+            lv_obj_clear_flag(lbl_battery_charge, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_add_flag(lbl_battery_charge, LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+
+    // Update percentage text
+    char buf[8];
+    snprintf(buf, sizeof(buf), "%d%%", percentage);
+    lv_label_set_text(lbl_battery_percent, buf);
+
+    last_battery_pct = percentage;
+    last_battery_state = state;
 }
 
 void UIMachineSelect::refreshMachineList() {

--- a/src/ui/ui_machine_select.cpp
+++ b/src/ui/ui_machine_select.cpp
@@ -102,11 +102,12 @@ void UIMachineSelect::show(lv_display_t *disp) {
         lv_obj_set_style_bg_color(battery_fill, UITheme::BATTERY_FULL, LV_PART_INDICATOR);
         lv_obj_set_style_radius(battery_fill, 0, LV_PART_INDICATOR);
 
-        // Lightning bolt overlay for charging (hidden by default)
+        // Lightning bolt overlay for charging (hidden by default).
+        // High-contrast light color so it stands out against the cyan charging fill.
         lbl_battery_charge = lv_label_create(screen);
         lv_label_set_text(lbl_battery_charge, LV_SYMBOL_CHARGE);
         lv_obj_set_style_text_font(lbl_battery_charge, &lv_font_montserrat_14, 0);
-        lv_obj_set_style_text_color(lbl_battery_charge, UITheme::BATTERY_CHARGING, 0);
+        lv_obj_set_style_text_color(lbl_battery_charge, UITheme::TEXT_LIGHT, 0);
         lv_obj_align_to(lbl_battery_charge, battery_body, LV_ALIGN_CENTER, 0, 0);
         lv_obj_add_flag(lbl_battery_charge, LV_OBJ_FLAG_HIDDEN);
 


### PR DESCRIPTION
Adds a compact graphical battery indicator powered by a MAX17048 I2C fuel gauge, shown in the main status bar and machine selection screen.

- Auto-detects MAX17048 on the shared I2C bus at startup; silently disables if not present so the feature is opt-in via hardware.
- Custom battery widget (outline + fill bar + nub + percentage label) with color coding: green (>55%), amber (20-55%), red (<20%), cyan (charging) with a lightning bolt overlay while charging.
- machine_name fixed width (80px) to keep top-row layout deterministic and prevent overlap with WPos Z and the battery widget.

<img width="800" height="480" alt="screenshot 3" src="https://github.com/user-attachments/assets/3ce6c3b3-fbf5-4068-8843-54bba3d24faf" />

