### PR TITLE
Fix file upload when using mDNS

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -4,7 +4,7 @@
 #include <Arduino.h>
 
 // Version
-#define FLUIDTOUCH_VERSION "1.0.5"
+#define FLUIDTOUCH_VERSION "1.0.5dev"
 
 // Display settings
 #define SCREEN_WIDTH  800

--- a/include/ui/machine_config.h
+++ b/include/ui/machine_config.h
@@ -16,6 +16,7 @@ struct MachineConfig {
     char ssid[33];           // WiFi SSID (max 32 chars + null)
     char password[64];       // WiFi password (max 63 chars + null)
     char fluidnc_url[128];   // FluidNC URL (e.g., "192.168.1.100" or "fluidnc.local")
+    char fluidnc_IP[128];    // Resolved IP saved from FluidNCClient::connect
     uint16_t websocket_port; // WebSocket port (default 81)
     bool is_configured;      // Whether this slot has a valid machine
     

--- a/src/network/fluidnc_client.cpp
+++ b/src/network/fluidnc_client.cpp
@@ -97,6 +97,8 @@ bool FluidNCClient::connect(const MachineConfig &config) {
     // Connect to WebSocket (ws://hostname:port/)
     char wsUrl[128];
     snprintf(wsUrl, sizeof(wsUrl), "ws://%s:%d/", resolvedHost.c_str(), config.websocket_port);
+    // Save the resolved IP to machine current config
+    snprintf(currentConfig.fluidnc_IP, sizeof(currentConfig.fluidnc_IP), resolvedHost.c_str());
     bool connected = webSocket.connect(wsUrl);
     
     if (!connected) {
@@ -196,8 +198,8 @@ void FluidNCClient::requestStatusReport() {
 String FluidNCClient::getMachineIP() {
     if (!currentStatus.is_connected) return "";
     
-    // Get URL from config
-    String url = String(currentConfig.fluidnc_url);
+    // Get IP saved from FluidNCClient::connect 
+    String url = String(currentConfig.fluidnc_IP);
     
     // Extract IP from URL (may already be just an IP address)
     // If it starts with a protocol, remove it


### PR DESCRIPTION
When using mDNS to connect FluidTouch to FluidNC, file uploads would fail. The call to FluidNCClient::getMachineIP from the upload procedure was not using mDNS to resolve the IP address and was just using the url from the connection definition.
The connection procedure, FluidNCClient::connect, used during initial connection of FluidTouch to FluidNC, does have an mDNS capability.

I made changes to save the IP address resolved during initial connect and then reuse this IP during file uploads.

I added a field to Machine Config to store the IP address that is resolved during initial connection. I added a line to FluidNCClient::connect. to save the resolved IP address to this field.

I revised FluidNCClient::getMachineIP to use the IP address saved in Machine Config instead of the url from the connection box.

I tested this on a Basic display and a version 1.4 Advanced display. 
I tested by using a hard coded IP address in the connection configuration, and by using fluidnc.local in the configuration.